### PR TITLE
feat: add is_ functions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ impl<'a> IsChar for &'a char {
 macro_rules! is_impl {
     ($($name:ident)*) => ($(
         #[inline(always)]
-        fn $name<T: IsChar>(item: T) -> bool {
+        pub fn $name<T: IsChar>(item: T) -> bool {
             item.as_char().$name()
         }
     )*);


### PR DESCRIPTION
This commit adds the already present `is_` functions to the public API.

Closes #3