### PR TITLE
Make it compatible with nom 7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,17 +7,15 @@ license = "MIT/Apache-2.0"
 name = "nom-unicode"
 readme = "README.md"
 repository = "https://github.com/Alexhuszagh/rust-nom-unicode"
-version = "0.2.0"
+version = "0.3.0"
 
 [badges]
 travis-ci = { repository = "Alexhuszagh/rust-nom-unicode" }
 
 [dependencies]
-nom = { version = "6.0", default-features = false }
+nom = { version = "7.0", default-features = false }
 
 [features]
 alloc = ["nom/alloc"]
 std = ["nom/std"]
-default = ["std", "lexical"]
-regexp = ["nom/regexp"]
-lexical = ["nom/lexical"]
+default = ["std"]


### PR DESCRIPTION
With these small changes the library is compatible with nom 7 (as requested in #6).
The features `lexical` and `regex` where removed in the 7.0 release.
